### PR TITLE
Bump setup.py version 0.9.6

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setup(
     # Versions should comply with PEP440.  For a discussion on single-sourcing
     # the version across setup.py and the project code, see
     # https://packaging.python.org/en/latest/single_source_version.html
-    version='0.9.5',
+    version='0.9.6',
 
     description='A fully featured, pythonic library for representing and using quaternions.',
     long_description="A fully featured, pythonic library for quaternion representation, manipulation, 3D animation and geometry.",


### PR DESCRIPTION
This was forgotten in #1 

Not sure how this affects the pending [bloom release](https://github.com/ros/rosdistro/pull/23794)