### PR TITLE
Revert "Add setter for vector"

### DIFF
--- a/pyquaternion/quaternion.py
+++ b/pyquaternion/quaternion.py
@@ -1122,13 +1122,6 @@ class Quaternion:
         """
         return self.q[1:4]
 
-    @vector.setter
-    def vector(self, v):
-        if len(v) != 3:
-            raise AttributeError("Expected vector component to be of length 3 but received length {} instead!"
-                                 .format(len(v)))
-        self.q[1:4] = v
-
     @property
     def real(self):
         return self.scalar


### PR DESCRIPTION
Reason: unlikely change to get approved. Instead users should initialize a new `Quaternion` object using the init kwargs `scalar` and `vector`